### PR TITLE
Fix/generate koa id missing dot

### DIFF
--- a/koa_middleware/file_utils.py
+++ b/koa_middleware/file_utils.py
@@ -55,4 +55,4 @@ def generate_koa_id(instrument_prefix : str, date_obs : str = None, utc_obs : st
     utc = datetime.datetime.strptime(utc_obs, '%H:%M:%S.%f')
     total_seconds = utc.hour * 3600 + utc.minute * 60 + utc.second + utc.microsecond / 1e6
     seconds = f"{total_seconds:08.2f}"
-    return f"{instrument_prefix}.{date_obs}.{seconds}{ext}"
+    return f"{instrument_prefix}.{date_obs}.{seconds}.{ext}"

--- a/tests/test_koa_id.py
+++ b/tests/test_koa_id.py
@@ -1,4 +1,4 @@
-from koa_middleware.file_utils import generate_koa_id
+from koa_middleware.file_utils import generate_koa_id, generate_koa_filepath
 
 def test_generate_koa_id():
     instrument_prefix = 'HB'
@@ -6,3 +6,14 @@ def test_generate_koa_id():
     utc_obs = '12:34:56.78'
     koa_id = generate_koa_id(instrument_prefix, date_obs, utc_obs)
     assert koa_id == 'HB.20240924.45296.78.fits'
+
+
+def test_generate_koa_filepath():
+    
+    instrument = 'HISPEC'
+    instrument_prefix = 'HB'
+    data_level = 'L1'
+    date_obs = '20240924'
+    utc_obs = '12:34:56.78'
+    koa_filepath = generate_koa_filepath(instrument, instrument_prefix, data_level, date_obs, utc_obs)
+    assert koa_filepath == '/HISPEC/2024/20240924/L1/HB.20240924.45296.78.fits'

--- a/tests/test_koa_id.py
+++ b/tests/test_koa_id.py
@@ -1,0 +1,8 @@
+from koa_middleware.file_utils import generate_koa_id
+
+def test_generate_koa_id():
+    instrument_prefix = 'HB'
+    date_obs = '20240924'
+    utc_obs = '12:34:56.78'
+    koa_id = generate_koa_id(instrument_prefix, date_obs, utc_obs)
+    assert koa_id == 'HB.20240924.45296.78.fits'


### PR DESCRIPTION
Small fixes for Generating KOA file ID and filepath. The relevant methods in `file_utils.py` are likely to evolve.